### PR TITLE
clue: updated with functionality to initialize metrics before they are dynamically emitted

### DIFF
--- a/metrics/http.go
+++ b/metrics/http.go
@@ -20,8 +20,48 @@ type (
 	}
 )
 
+// HTTPEndpointDetails provides information about the endpoint, using each attribute as a label in the metric.
+type HTTPEndpointDetails struct {
+	// Path represents the relative path pattern (i.e. /api/v1/status)
+	Path string
+	// Verb represents the verb used on the endpoint resource (i.e. GET)
+	Verb string
+}
+
+// InitMetricDetails includes details about the server host, status codes, and path/verb for each endpoint.
+// This is used to figure out which specific metric combination to initialize.
+type InitMetricDetails struct {
+	// EndpointDetails are the HTTP details for each Path + Verb combo.
+	EndpointDetails []HTTPEndpointDetails
+	// Host is the host of the actual running server.
+	Host string
+	// StatusCodes are the set of status codes that are possible for the endpoints (i.e. 400, 500, 200)
+	StatusCodes []string
+}
+
 // Be kind to tests
 var timeSince = time.Since
+
+// initMetrics initializes all metrics that are specified in the init details,
+// for all given status ports. This is important from a metrics standpoint so
+// that the metric is properly reported -> makes computations easier.
+func initMetrics(metrics *httpMetrics, initDetails *InitMetricDetails) {
+	if initDetails == nil || len(initDetails.EndpointDetails) == 0 {
+		return
+	}
+
+	for _, detail := range initDetails.EndpointDetails {
+		for _, code := range initDetails.StatusCodes {
+			labels := prometheus.Labels{
+				labelHTTPVerb:       detail.Verb,
+				labelHTTPPath:       detail.Path,
+				labelHTTPHost:       initDetails.Host,
+				labelHTTPStatusCode: code,
+			}
+			metrics.Durations.With(labels)
+		}
+	}
+}
 
 // HTTP returns a middlware that metricss requests. The context must have
 // been initialized with Context. HTTP collects the following metrics:
@@ -40,13 +80,14 @@ var timeSince = time.Since
 //
 // Errors collecting or serving metrics are logged to the logger in the context
 // if any.
-func HTTP(ctx context.Context) func(http.Handler) http.Handler {
+func HTTP(ctx context.Context, initDetails *InitMetricDetails) func(http.Handler) http.Handler {
 	b := ctx.Value(stateBagKey)
 	if b == nil {
 		panic("initialize context with Context first")
 	}
 	metrics := b.(*stateBag).HTTPMetrics()
 	resolver := b.(*stateBag).options.resolver
+	initMetrics(metrics, initDetails)
 
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/metrics/http_test.go
+++ b/metrics/http_test.go
@@ -30,7 +30,7 @@ func TestHTTPServerDuration(t *testing.T) {
 
 			reg := NewTestRegistry(t)
 			ctx := Context(context.Background(), "testsvc", WithRegisterer(reg), WithDurationBuckets(buckets))
-			middleware := HTTP(ctx)
+			middleware := HTTP(ctx, nil)
 			cli, stop := testsvc.SetupHTTP(t,
 				testsvc.WithHTTPMiddleware(middleware),
 				testsvc.WithHTTPFunc(noopMethod()))
@@ -60,7 +60,7 @@ func TestHTTPRequestSize(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			reg := NewTestRegistry(t)
 			ctx := Context(context.Background(), "testsvc", WithRegisterer(reg), WithRequestSizeBuckets(buckets))
-			middleware := HTTP(ctx)
+			middleware := HTTP(ctx, nil)
 			cli, stop := testsvc.SetupHTTP(t,
 				testsvc.WithHTTPMiddleware(middleware),
 				testsvc.WithHTTPFunc(noopMethod()))
@@ -91,7 +91,7 @@ func TestHTTPResponseSize(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			reg := NewTestRegistry(t)
 			ctx := Context(context.Background(), "testsvc", WithRegisterer(reg), WithResponseSizeBuckets(buckets))
-			middleware := HTTP(ctx)
+			middleware := HTTP(ctx, nil)
 			cli, stop := testsvc.SetupHTTP(t,
 				testsvc.WithHTTPMiddleware(middleware),
 				testsvc.WithHTTPFunc(stringMethod(c.str)))
@@ -120,7 +120,7 @@ func TestHTTPActiveRequests(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			reg := NewTestRegistry(t)
 			ctx := Context(context.Background(), "testsvc", WithRegisterer(reg))
-			middleware := HTTP(ctx)
+			middleware := HTTP(ctx, nil)
 			chstop := make(chan struct{})
 			var running, done sync.WaitGroup
 			running.Add(c.numReqs)


### PR DESCRIPTION


This change is largely motivated by wanting data present for each endpoint + status code combination. Previously certain calculations were very difficult or impossible in Grafana Prometheus because of missing data especially when grouping by labels.

This new middleware allows you to pass in options to configure certain metrics to be initialized.